### PR TITLE
Working failover command

### DIFF
--- a/pkg/streams/filter.go
+++ b/pkg/streams/filter.go
@@ -58,5 +58,5 @@ func RevisionFilter(logger kitlog.Logger, in <-chan *mvccpb.KeyValue) <-chan *mv
 }
 
 func withKv(logger kitlog.Logger, kv *mvccpb.KeyValue) kitlog.Logger {
-	return kitlog.With(logger, "key", string(kv.Key), "value", string(kv.Value), "revision", kv.ModRevision)
+	return kitlog.With(logger, "key", string(kv.Key), "revision", kv.ModRevision)
 }


### PR DESCRIPTION
Implement failover command by polling stolon state to ensure we have a
master with sufficient healthy standbys. This appears to work in our
tests, but we'll be following up with a proper acceptance test that
should verify the flow better.