### PR TITLE
Add PgBouncer healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
     entrypoint:
       - /stolon-pgbouncer/bin/stolon-pgbouncer.linux_amd64
       - supervise
-      - --enable-child-process
       - --pgbouncer-config-template-file=/stolon-pgbouncer/docker/stolon-development/pgbouncer/pgbouncer.ini.template
       - --poll-interval=5s
     volumes:

--- a/pkg/pgbouncer/pgbouncer.go
+++ b/pkg/pgbouncer/pgbouncer.go
@@ -87,7 +87,7 @@ type Database struct {
 	CurrentConnections int64
 }
 
-// ShowDatabase extracts information from the SHOW DATABASE PgBouncer command, selecting
+// ShowDatabases extracts information from the SHOW DATABASES PgBouncer command, selecting
 // columns about database host details. This is quite cumbersome to write, due to the
 // inability to query select fields for database information, and the lack of guarantees
 // about the ordering of the columns returned from the command.


### PR DESCRIPTION
This PR does two things:

- Adds a `stolon-pgbouncer healthcheck` command which can be used to
healthcheck the local pgbouncer. This can only be used by the
stolon-pgbouncer on the postgres box. The primary use case for this will be to test that we've configured the connection between stolon-pgbouncer and pgbouncer correctly.

- Removes the `--supervise-child-process` flag, since we will always set
it to true, so it's a bit confusing that it's configurable.