### PR TITLE
failover --health-check-only, check PgBouncer

### DIFF
--- a/pkg/failover/server.go
+++ b/pkg/failover/server.go
@@ -45,9 +45,15 @@ func (s *Server) LoggingInterceptor(ctx context.Context, req interface{}, info *
 }
 
 func (s *Server) HealthCheck(ctx context.Context, _ *Empty) (*HealthCheckResponse, error) {
-	return &HealthCheckResponse{
-		Status: HealthCheckResponse_HEALTHY,
-	}, nil
+	resp := &HealthCheckResponse{Status: HealthCheckResponse_HEALTHY}
+
+	// TODO: Provide error in the health check response
+	// https://github.com/gocardless/stolon-pgbouncer/pull/11
+	if _, err := s.bouncer.ShowDatabases(ctx); err != nil {
+		resp.Status = HealthCheckResponse_UNHEALTHY
+	}
+
+	return resp, nil
 }
 
 func (s *Server) Pause(ctx context.Context, req *PauseRequest) (resp *PauseResponse, err error) {


### PR DESCRIPTION
Provide the option to just health check the failover endpoints, useful
if you want to validate everything is responsive in a test environment
etc.

Also check the PgBouncer health when running health checks. This makes
it easy to verify everything is ready before committing to a failover,
potentially pausing other working PgBouncers when you'll inevitably fail
due to a bad node.