### PR TITLE
Don't require ignore_startup_parameters

### DIFF
--- a/docker/stolon-development/pgbouncer/pgbouncer.ini
+++ b/docker/stolon-development/pgbouncer/pgbouncer.ini
@@ -21,4 +21,3 @@ reserve_pool_size = 5
 log_connections = 1
 log_disconnections = 1
 log_pooler_errors = 1
-ignore_startup_parameters = extra_float_digits

--- a/docker/stolon-development/pgbouncer/pgbouncer.ini.template
+++ b/docker/stolon-development/pgbouncer/pgbouncer.ini.template
@@ -21,4 +21,3 @@ reserve_pool_size = 5
 log_connections = 1
 log_disconnections = 1
 log_pooler_errors = 1
-ignore_startup_parameters = extra_float_digits

--- a/pkg/pgbouncer/integration/pgbouncer.go
+++ b/pkg/pgbouncer/integration/pgbouncer.go
@@ -85,8 +85,7 @@ unix_socket_dir = %s
 auth_type = trust
 auth_file = %s/users.txt
 admin_users = postgres,pgbouncer
-pool_mode = %s
-ignore_startup_parameters = extra_float_digits`, database, port, workspace, workspace, workspace, poolMode)),
+pool_mode = %s`, database, port, workspace, workspace, workspace, poolMode)),
 			0644,
 		)
 

--- a/pkg/pgbouncer/pgbouncer.go
+++ b/pkg/pgbouncer/pgbouncer.go
@@ -71,14 +71,6 @@ func (b *PgBouncer) createTemplate() (*template.Template, error) {
 		return nil, errors.Wrap(err, "failed to read PgBouncer config template file")
 	}
 
-	if matched, _ := regexp.Match("ignore_startup_parameters\\s*\\=.+extra_float_digits", configTemplate); !matched {
-		return nil, errors.Errorf(
-			"PgBouncer is misconfigured: expected config file '%s' to define "+
-				"'ignore_startup_paramets' to include 'extra_float_digits'",
-			b.ConfigTemplateFile,
-		)
-	}
-
 	return template.Must(template.New("PgBouncerConfig").Parse(string(configTemplate))), err
 }
 

--- a/pkg/pgbouncer/testdata/pgbouncer.ini.template
+++ b/pkg/pgbouncer/testdata/pgbouncer.ini.template
@@ -21,4 +21,3 @@ reserve_pool_size = 5
 log_connections = 1
 log_disconnections = 1
 log_pooler_errors = 1
-ignore_startup_parameters = extra_float_digits


### PR DESCRIPTION
[^1]: https://github.com/lib/pq/issues/475

lib/pq sends extra_float_digits as a startup parameter [^1] whenever
initialising a Postgres connection. PgBouncer doesn't recognise this
parameter and will fail whenever you send it.

To prevent this, we ensured pgsql-cluster-manager would ban PgBouncer
configuration that didn't explicitly ignore this parameter. This is
likely irrelevant after we moved to pgx though, so we should remove this
constraint.