### PR TITLE
Expose keeper as label

### DIFF
--- a/cmd/stolon-pgbouncer/main.go
+++ b/cmd/stolon-pgbouncer/main.go
@@ -130,11 +130,12 @@ var (
 			Help: "Number of outstanding connections in PgBouncer during shutdown",
 		},
 	)
-	HostHash = prometheus.NewGauge(
+	HostHash = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "stolon_pgbouncer_host_hash",
 			Help: "MD5 hash of the last successfully reloaded host value",
 		},
+		[]string{"keeper"},
 	)
 	StorePollInterval = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -403,8 +404,10 @@ func main() {
 							}
 
 							// Set metrics that power alerts. These values are only set when we've
-							// succeeded in reloading PgBouncer.
-							HostHash.Set(md5float(masterAddress))
+							// succeeded in reloading PgBouncer. We provide the keeper UID as our label
+							// value considering this will be more readable than our listen address.
+							HostHash.Reset()
+							HostHash.WithLabelValues(master.Spec.KeeperUID).Set(md5float(masterAddress))
 							LastReloadSeconds.Set(float64(time.Now().Unix()))
 
 							return nil


### PR DESCRIPTION
Prometheus discourages this type of behaviour, where you add dynamic
information into labels. In this case we'll have very few host values
that will appear here, so it doesn't matter so much if we do this.

We'll use this label to provide a recognisable textual host value in our
diagnostic dashboards, allowing us to easily list which pods are
connected to which host.