### PR TITLE
stolon_pgbouncer_cluster_identifier = 1

### DIFF
--- a/cmd/stolon-pgbouncer/main.go
+++ b/cmd/stolon-pgbouncer/main.go
@@ -118,7 +118,7 @@ var (
 	ClusterIdentifier = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "stolon_pgbouncer_cluster_identifier",
-			Help: "MD5 hash of the cluster name and store prefix",
+			Help: "Set to 1, is labelled with store_prefix and cluster_name",
 		},
 		[]string{"store_prefix", "cluster_name"},
 	)
@@ -290,9 +290,7 @@ func main() {
 		pgBouncer := mustPgBouncer(supervisePgBouncerOptions)
 		stopt := superviseStolonOptions
 
-		ClusterIdentifier.
-			WithLabelValues(stopt.Prefix, stopt.ClusterName).
-			Set(md5float(stopt.Prefix + stopt.ClusterName))
+		ClusterIdentifier.WithLabelValues(stopt.Prefix, stopt.ClusterName).Set(1)
 		StorePollInterval.Set(float64(*supervisePollInterval / time.Second))
 
 		if !*superviseChildProcess {


### PR DESCRIPTION
We label this metric with the relevant information, so don't need to set
the value to the hash of our cluster. I had initially suspected doing so
might be useful, but I've ended up multiplying this value by 0 and
adding 1 in every case I've used it, implying it's not useful at all.