### PR TITLE
Don't expect PgBouncer to be reloaded

### DIFF
--- a/cmd/stolon-pgbouncer/main.go
+++ b/cmd/stolon-pgbouncer/main.go
@@ -134,24 +134,31 @@ var (
 			Help: "Number of outstanding connections in PgBouncer during shutdown",
 		},
 	)
-	HostHash = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "stolon_pgbouncer_host_hash",
-			Help: "MD5 hash of the last successfully reloaded host value",
-		},
-		[]string{"keeper"},
-	)
 	StorePollInterval = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "stolon_pgbouncer_store_poll_interval",
 			Help: "Seconds between each store poll attempt",
 		},
 	)
-	LastReloadSeconds = prometheus.NewGauge(
+	StoreLastUpdateSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_pgbouncer_store_last_update_seconds",
+			Help: "Last time we received a value from our store as seconds since unix epoch",
+		},
+	)
+	LastKeeperSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "stolon_pgbouncer_last_keeper_seconds",
+			Help: "Most recent primary keeper update time since unix epoch in seconds",
+		},
+		[]string{"keeper"},
+	)
+	LastReloadSeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "stolon_pgbouncer_last_reload_seconds",
 			Help: "Most recent PgBouncer reload time since unix epoch in seconds",
 		},
+		[]string{"keeper"},
 	)
 )
 
@@ -159,8 +166,9 @@ func init() {
 	prometheus.MustRegister(ClusterIdentifier)
 	prometheus.MustRegister(ShutdownSeconds)
 	prometheus.MustRegister(OutstandingConnections)
-	prometheus.MustRegister(HostHash)
 	prometheus.MustRegister(StorePollInterval)
+	prometheus.MustRegister(StoreLastUpdateSeconds)
+	prometheus.MustRegister(LastKeeperSeconds)
 	prometheus.MustRegister(LastReloadSeconds)
 }
 
@@ -188,7 +196,7 @@ func main() {
 
 	go func() {
 		<-ctx.Done()
-		ShutdownSeconds.Set(float64(time.Now().Unix()))
+		ShutdownSeconds.SetToCurrentTime()
 	}()
 
 	switch command {
@@ -381,6 +389,12 @@ func main() {
 
 			kvs, _ := etcd.NewStream(logger, client, streamOptions)
 
+			// Before we filter revisions, update our last seen metric so we can detect if etcd
+			// has become unresponsive.
+			kvs = streams.Tap(kvs, func(kv *mvccpb.KeyValue) {
+				StoreLastUpdateSeconds.SetToCurrentTime()
+			})
+
 			// etcd provides events out-of-order, and potentially duplicated. We need to use the
 			// RevisionFilter to ensure we only fold our events in their logical order, without
 			// duplicates.
@@ -399,6 +413,7 @@ func main() {
 
 							// It's possible for kv to be nil if our stream is being shutdown
 							if kv == nil {
+								logger.Log("event", "nil_kv", "msg", "nil kv value, channel is shutting down")
 								return nil
 							}
 
@@ -414,6 +429,11 @@ func main() {
 								return nil
 							}
 
+							// Set our metric to signal we've received a new keeper. This allows us to
+							// compare the time between seeing our new keeper and updating PgBouncer.
+							LastKeeperSeconds.Reset()
+							LastKeeperSeconds.WithLabelValues(master.Spec.KeeperUID).SetToCurrentTime()
+
 							logger.Log("event", "generate_configuration", "host", master)
 							if err := pgBouncer.GenerateConfig(masterAddress); err != nil {
 								return err
@@ -424,12 +444,11 @@ func main() {
 								return err
 							}
 
-							// Set metrics that power alerts. These values are only set when we've
-							// succeeded in reloading PgBouncer. We provide the keeper UID as our label
-							// value considering this will be more readable than our listen address.
-							HostHash.Reset()
-							HostHash.WithLabelValues(master.Spec.KeeperUID).Set(md5float(masterAddress))
-							LastReloadSeconds.Set(float64(time.Now().Unix()))
+							// We only set this metric when we've successfully reloaded PgBouncer with
+							// the new keeper value. Alerts should detect when this value is stale when
+							// compared to the last known update.
+							LastReloadSeconds.Reset()
+							LastReloadSeconds.WithLabelValues(master.Spec.KeeperUID).SetToCurrentTime()
 
 							return nil
 						},

--- a/docker/observability/grafana/dashboards/stolon-pgbouncer.json
+++ b/docker/observability/grafana/dashboards/stolon-pgbouncer.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1555608684071,
+  "id": 62,
+  "iteration": 1556008997240,
   "links": [],
   "panels": [
     {
@@ -45,7 +46,7 @@
           "type": "date"
         },
         {
-          "alias": "time_since_reload",
+          "alias": "last_saw_update (store)",
           "colorMode": "row",
           "colors": [
             "rgba(255, 255, 255, 0)",
@@ -80,10 +81,11 @@
       ],
       "targets": [
         {
-          "expr": "max by (pod_name, cluster_name, store_prefix, keeper) (\n  time() - stolon_pgbouncer_last_reload_seconds * on(pod_name) group_left(cluster_name, store_prefix, keeper) (\n    stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"} != ignoring(cluster_name, store_prefix, keeper) group_left(keeper) stolon_pgbouncer_host_hash\n  )\n)",
+          "expr": "max by (pod_name, cluster_name, store_prefix, keeper) (\n  time() - stolon_pgbouncer_store_last_update_seconds * on(pod_name) group_left(cluster_name, store_prefix, keeper) (\n    stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"} != ignoring(cluster_name, store_prefix, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds\n  )\n)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -103,7 +105,7 @@
       "description": "stolon-pgbouncer controls a PgBouncer to point at our master Postgres. This graph visualises the number of PgBouncers that are pointed at each keeper. Something is wrong if more than one keeper is being proxied.",
       "fill": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 24,
         "x": 0,
         "y": 6
@@ -128,12 +130,11 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
-      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count_values by (keeper) (\n  \"__value__\", stolon_pgbouncer_host_hash and ignoring(cluster_name, store_prefix, keeper) stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"}\n)",
+          "expr": "count by (keeper) (\n  stolon_pgbouncer_last_reload_seconds and ignoring(cluster_name, store_prefix, keeper) stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"}\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ keeper }}",
@@ -195,7 +196,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 12,
       "legend": {
@@ -217,12 +218,107 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
-      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "time() - ((stolon_pgbouncer_last_reload_seconds > 0) and ignoring(cluster_name, store_prefix) stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"})",
+          "expr": "time() - ((stolon_pgbouncer_store_last_update_seconds > 0) and ignoring(cluster_name, store_prefix, keeper) stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ pod_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 120,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Time since last store update",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Tracks the time passed since the last PgBouncer reload. We expect stolon-pgbouncer to periodically reload PgBouncer, so this has exceeded the store poll interval then we know PgBouncer reloading is failing.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "time() - ((stolon_pgbouncer_last_reload_seconds > 0) and ignoring(cluster_name, store_prefix, keeper) stolon_pgbouncer_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod_name }}",
@@ -289,10 +385,10 @@
       "description": "After receiving a SIGTERM stolon-pgbouncer will wait for PgBouncer to finish serving requests before fully terminating. We expect our termination grace period to be 2hrs which is where we'll terminate our pod regardless of outstanding connections: this is where we set our threshold.",
       "fill": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 29
       },
       "id": 11,
       "legend": {
@@ -314,7 +410,6 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
-      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -386,18 +481,18 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [
-    "stolon",
-    "postgresql"
+    "postgres",
+    "stolon"
   ],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "mon-prometheus-0",
+          "value": "mon-prometheus-0"
         },
         "hide": 0,
         "label": null,
@@ -412,8 +507,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "main",
-          "value": "main"
+          "text": "lab-production/main",
+          "value": "lab-production/main"
         },
         "datasource": "$datasource",
         "definition": "label_values(stolon_pgbouncer_cluster_identifier, cluster_name)",
@@ -470,7 +565,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -494,5 +589,5 @@
   "timezone": "",
   "title": "stolon-pgbouncer",
   "uid": "0LgcjLRZz",
-  "version": 1
+  "version": 25
 }

--- a/docker/observability/prometheus/rules.yml
+++ b/docker/observability/prometheus/rules.yml
@@ -20,19 +20,20 @@ groups:
           summary: PgBouncers in this cluster are pointed at multiple masters
           description: |
 
-            The {{ $labels.cluster_name }} cluster has PgBouncers that are
-            pointed at more than one keeper. We only ever try to point at the
-            master, and we don't support multiple masters, so this means
-            something has gone astray.
+            The {{ $labels.cluster_name }} cluster has PgBouncers that are pointed at more
+            than one keeper. This should still be safe, as connections to replicas will be
+            proxied to the master by stolon-proxy. However we should clean up these
+            connections as we'll be bypassing the pooling restrictions imposed by the
+            master PgBouncer.
 
-            Jump into the dashboard to figure out which pod has gone wrong- it
+            Jump into the dashboard to figure out which pod has gone wrong - it
             will likely be highlighted in red, and won't have reloaded PgBouncer
             in some time.
 
-            Connections via this PgBouncer won't currently be functioning, so
-            your first action should be to kill the pod. If new pods come back
-            and immediately point elsewhere then you need to debug etcd or the
-            cluster itself.
+            To gracefully drain all connections from this pod, just delete it. It'll wait
+            up to 3 hours before shutting down to make sure all connections have closed.
+            If the new pod comes back and doesn't point itself to the master then you need
+            to debug etcd or the cluster itself.
 
       - alert: StolonPgBouncerPendingShutdown
         expr: >

--- a/docker/observability/prometheus/rules.yml
+++ b/docker/observability/prometheus/rules.yml
@@ -5,11 +5,13 @@ groups:
       - alert: StolonPgBouncerMultipleMasters
         # Count the number of distinct (cluster_name, keeper) label pairs we
         # have, then roll-up by cluster_name. This tells us if the same cluster
-        # is pointing at multiple keepers.
+        # is pointing at multiple keepers. Use the last_reload metric to ensure
+        # the keeper value is what we've successfully loaded PgBouncer to point
+        # at.
         expr: >
           count by (cluster_name) (
             count by (cluster_name, keeper) (
-              stolon_pgbouncer_cluster_identifier * ignoring(cluster_name, store_prefix, keeper) group_left(keeper) stolon_pgbouncer_host_hash
+              stolon_pgbouncer_cluster_identifier * ignoring(cluster_name, store_prefix, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds
             )
           ) > 1
         labels:
@@ -70,14 +72,46 @@ groups:
             pgbouncer=# show databases;
             ...
             ```
-      - alert: StolonPgBouncerStaleReload
-        # Ensure we don't alert when shutdown_seconds > 0, as we expect not to
-        # reload PgBouncer when we're shutting down. Pending shutdowns should be
-        # caught by the StolonPgBouncerPendingShutdown alert, not this.
+
+      - alert: StolonPgBouncerStaleStore
+        # Ensure we don't alert when shutdown_seconds > 0, as we'll have torn
+        # down our etcd listeners once we begin shutdown.
         expr: >
           max by (pod_name, namespace, version) (
             stolon_pgbouncer_cluster_identifier * ignoring(cluster_name, store_prefix) (
-              (time() - stolon_pgbouncer_last_reload_seconds) > (2 * stolon_pgbouncer_store_poll_interval and stolon_pgbouncer_shutdown_seconds == 0)
+              (time() - stolon_pgbouncer_store_last_update_seconds) > (2 * stolon_pgbouncer_store_poll_interval and stolon_pgbouncer_shutdown_seconds == 0)
+            )
+          )
+        labels:
+          severity: critical
+        annotations:
+          summary: Stale clusterdata updates from etcd on {{ $labels.pod_name }}
+          description: |
+
+            stolon-pgbouncer watches and polls the etcd store every poll
+            interval seconds. This alert is firing if more than 2x the poll
+            interval has elapsed since we last received a value from our store.
+
+            This likely means our etcd connection has malfunctioned, or we're
+            failing to poll etcd. Checking the pod logs will show any poll
+            errors (polling retries continuously) and should hint at what's gone
+            wrong.
+
+            ```
+            $ kubectl logs -f -n {{ $labels.namespace }} {{ $labels.pod_name }}
+            ```
+
+      - alert: StolonPgBouncerStaleReload
+        # Find where the last time we successfully reloaded PgBouncer was
+        # greater than 5s behind the last updated keeper value. We'll fire this
+        # alert whenever PgBouncer is failing to handle reloads.
+        #
+        # As with StolonPgBouncerStaleStore, don't alert when we're shutting
+        # down as we expect to stop listening to store updates on shutdown.
+        expr: >
+          max by (pod_name, namespace, version) (
+            stolon_pgbouncer_cluster_identifier * ignoring(cluster_name, store_prefix) group_right(cluster_name, store_prefix) (
+              stolon_pgbouncer_last_keeper_seconds - ignoring(keeper) stolon_pgbouncer_last_reload_seconds > 5
             )
           )
         labels:
@@ -86,17 +120,15 @@ groups:
           summary: Failed to reload PgBouncer on {{ $labels.pod_name }}
           description: |
 
-            stolon-pgbouncer tries to reload PgBouncer every store poll interval
-            seconds, but this pod has failed to do so for more than 2x this
-            interval.
+            stolon-pgbouncer tries reloading PgBouncer in response to keeper
+            changes. This alert fires whenever we've seen a new primary keeper
+            but have not indicated that PgBouncer has been reloaded with the new
+            value.
 
-            Either our connection to etcd is broken or PgBouncer is
-            unresponsive, either of which mean database failover won't update
-            this PgBouncer.
-
-            Logging into the pod and checking the live processes can show
-            whether a PgBouncer has died, and accessing the console might help
-            determine the route of the problem.
+            It's likely that PgBouncer has hung, or maybe the configuration file
+            is invalid and cannot be reloaded. First check pod logs for errors,
+            failing that exec into the pod to check the pgbouncer.ini file and
+            state of the PgBouncer process.
 
             ```
             $ kubectl -n {{ $labels.namespace }} exec -it {{ $labels.pod_name }} bash


### PR DESCRIPTION
I've significantly rejigged the alerts now, so I'm going to create a checklist like we had in anu for whoever comes to review, only difference being that people should test locally against docker-compose.

Run `docker-compose up` before any of these steps.

## Store becomes unresponsive (`StolonPgBouncerStaleStore`)

- [x] Pause etcd (`docker-compose pause etcd-store`)
- [x] Watch dashboard to see "Time since last store update" is increasing
- [x] Verify `StolonPgBouncerStaleStore` is firing in localhost:9090/alerts
  - This was delayed by about 1 minute - maybe because of the `evaluation_interval`?
- [x] Resume etcd (`docker-compose unpause etcd-store`)
- [x] Confirm alert resolves

## PgBouncer is failing to reload (`StolonPgBouncerStaleReload`)

- [x] Exec into a stolon-pgbouncer pod (`docker-compose exec pgbouncer bash`)
- [x] `pkill -STOP pgbouncer` freezing the PgBouncer process
- [x] Observe the time since last reload is increasing in the dashboard for this pod
- [x] Confirm `StolonPgBouncerStaleReload` alert in localhost:9090/alerts
  - Interestingly, I also saw the `StolonPgBouncerStaleStore` alert fire
- [x] `pkill -CONT pgbouncer` unpause PgBouncer process
- [x] Confirm alert resolves

## Pending shutdown (`StolonPgBouncerPendingShutdown`)

- [x] Connect locally via the PgBouncer (`psql -h localhost -p 6432 -U postgres postgres`)
- [x] Run `select now()` to confirm your connection is valid
- [x] Login to pgbouncer pod and issue sigterm (`docker-compose exec pgbouncer kill 1`)
- [x] Confirm logged intent to shutdown (`docker-compose logs pgbouncer | grep event`)
- [x] Confirm dashboard shows pending shutdown seconds increasing
- [x] Confirm `StolonPgBouncerPendingShutdown` alert after 3m

## Divergent masters (`StolonPgBouncerMultipleMasters`)

This isn't testable in our test setup, as we don't have multiple stolon-pgbouncers. Worth doing though, just to check that the pgbouncer in shutdown is stuck in a stale keeper state. Eyeballing the alert to check it would function correctly if we had multiple PgBouncers would also be :aces:

- [ ] Relying on the previous step-by-step processes, login to the sentinel pod (`docker-compose exec sentinel bash`)
- [ ] Use `stolonctl status` to check which keeper is currently master
- [ ] Fail this keeper using `stolonctl failkeeper <keeper-name>`, causing the primary to move
- [ ] Confirm shutting down keeper is still pointed at old primary
- [ ] Normally, `StolonPgBouncerMultipleMasters` would be firing if other PgBouncers had moved while our shutting down container had not. It won't in this case, but check the alert would in a >1 setup
- [ ] Exit the psql prompt
- [ ] Confirm the container exits when all connections are closed