### PR TITLE
Drop store_prefix label from metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
 
 BASE_TAG=2019040201
 CIRCLECI_TAG=2019040303
-STOLON_DEVELOPMENT_TAG=2019043001
+STOLON_DEVELOPMENT_TAG=2019051001
 
 .PHONY: all darwin linux test clean test-acceptance docker-compose
 

--- a/cmd/stolon-pgbouncer/main.go
+++ b/cmd/stolon-pgbouncer/main.go
@@ -137,9 +137,9 @@ var (
 	clusterIdentifier = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "stolon_cluster_identifier",
-			Help: "Set to 1, is labelled with store_prefix and cluster_name",
+			Help: "Set to 1, is labelled with the cluster_name",
 		},
-		[]string{"store_prefix", "cluster_name"},
+		[]string{"cluster_name"},
 	)
 	shutdownSeconds = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -352,7 +352,7 @@ func main() {
 		pgBouncer := mustPgBouncer(supervisePgBouncerOptions)
 		stopt := superviseStolonOptions
 
-		clusterIdentifier.WithLabelValues(stopt.Prefix, stopt.ClusterName).Set(1)
+		clusterIdentifier.WithLabelValues(stopt.ClusterName).Set(1)
 		storePollInterval.Set(float64(*supervisePollInterval / time.Second))
 
 		var logger = kitlog.With(logger, "component", "pgbouncer.child")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - etcd-store
 
   sentinel:
-    image: &stolonDevelopmentImage gocardless/stolon-development:2019043001
+    image: &stolonDevelopmentImage gocardless/stolon-development:2019051001
     restart: on-failure
     depends_on:
       - etcd-store

--- a/docker/observability/grafana/dashboards/stolon-keeper.json
+++ b/docker/observability/grafana/dashboards/stolon-keeper.json
@@ -135,7 +135,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "time() - ((stolon_keeper_last_sync_success_seconds > 0) and ignoring(cluster_name, store_prefix) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
+          "expr": "time() - ((stolon_keeper_last_sync_success_seconds > 0) and ignoring(cluster_name) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",
@@ -232,7 +232,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "time() - ((stolon_keeper_clusterdata_last_valid_update_seconds > 0) and ignoring(cluster_name, store_prefix) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
+          "expr": "time() - ((stolon_keeper_clusterdata_last_valid_update_seconds > 0) and ignoring(cluster_name) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",

--- a/docker/observability/grafana/dashboards/stolon-pgbouncer.json
+++ b/docker/observability/grafana/dashboards/stolon-pgbouncer.json
@@ -81,7 +81,7 @@
       ],
       "targets": [
         {
-          "expr": "max by (pod_name, cluster_name, store_prefix, keeper) (\n  time() - stolon_pgbouncer_store_last_update_seconds * on(pod_name) group_left(cluster_name, store_prefix, keeper) (\n    stolon_cluster_identifier{cluster_name=\"$cluster\"} != ignoring(cluster_name, store_prefix, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds\n  )\n)",
+          "expr": "max by (pod_name, cluster_name, keeper) (\n  time() - stolon_pgbouncer_store_last_update_seconds * on(pod_name) group_left(cluster_name, keeper) (\n    stolon_cluster_identifier{cluster_name=\"$cluster\"} != ignoring(cluster_name, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds\n  )\n)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -134,7 +134,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count by (keeper) (\n  stolon_pgbouncer_last_reload_seconds and ignoring(cluster_name, store_prefix, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"}\n)",
+          "expr": "count by (keeper) (\n  stolon_pgbouncer_last_reload_seconds and ignoring(cluster_name, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"}\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ keeper }}",
@@ -222,7 +222,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "time() - ((stolon_pgbouncer_store_last_update_seconds > 0) and ignoring(cluster_name, store_prefix, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
+          "expr": "time() - ((stolon_pgbouncer_store_last_update_seconds > 0) and ignoring(cluster_name, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod_name }}",
@@ -318,7 +318,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "time() - ((stolon_pgbouncer_last_reload_seconds > 0) and ignoring(cluster_name, store_prefix, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
+          "expr": "time() - ((stolon_pgbouncer_last_reload_seconds > 0) and ignoring(cluster_name, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod_name }}",
@@ -414,7 +414,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "time() - ((stolon_pgbouncer_shutdown_seconds > 0) and ignoring(cluster_name, store_prefix) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
+          "expr": "time() - ((stolon_pgbouncer_shutdown_seconds > 0) and ignoring(cluster_name) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod_name }}",

--- a/docker/observability/prometheus/rules.yml
+++ b/docker/observability/prometheus/rules.yml
@@ -11,7 +11,7 @@ groups:
         expr: >
           count by (cluster_name) (
             count by (cluster_name, keeper) (
-              stolon_cluster_identifier * ignoring(cluster_name, store_prefix, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds
+              stolon_cluster_identifier * ignoring(cluster_name, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds
             )
           ) > 1
         labels:
@@ -38,7 +38,7 @@ groups:
       - alert: StolonPgBouncerPendingShutdown
         expr: >
           max by (pod_name, namespace, version) (
-            stolon_cluster_identifier * ignoring(cluster_name, store_prefix) (
+            stolon_cluster_identifier * ignoring(cluster_name) (
               time() - (stolon_pgbouncer_shutdown_seconds > 0)
             ) > 180
           )
@@ -79,7 +79,7 @@ groups:
         # down our etcd listeners once we begin shutdown.
         expr: >
           max by (pod_name, namespace, version) (
-            stolon_cluster_identifier * ignoring(cluster_name, store_prefix) (
+            stolon_cluster_identifier * ignoring(cluster_name) (
               (time() - stolon_pgbouncer_store_last_update_seconds) > (2 * stolon_pgbouncer_store_poll_interval and stolon_pgbouncer_shutdown_seconds == 0)
             )
           )
@@ -111,7 +111,7 @@ groups:
         # down as we expect to stop listening to store updates on shutdown.
         expr: >
           max by (pod_name, namespace, version) (
-            stolon_cluster_identifier * ignoring(cluster_name, store_prefix) group_right(cluster_name, store_prefix) (
+            stolon_cluster_identifier * ignoring(cluster_name) group_right(cluster_name) (
               stolon_pgbouncer_last_keeper_seconds - ignoring(keeper) stolon_pgbouncer_last_reload_seconds > 5
             )
           )
@@ -147,7 +147,7 @@ groups:
     rules:
       - alert: StolonKeeperStaleSync
         expr: >
-          stolon_cluster_identifier * on(instance) group_right(cluster_name, store_prefix) (
+          stolon_cluster_identifier * on(instance) group_right(cluster_name) (
             time() - stolon_keeper_last_sync_success_seconds
           ) > 60
         labels:
@@ -165,7 +165,7 @@ groups:
 
       - alert: StolonKeeperRequiresRestart
         expr: >
-          stolon_cluster_identifier * on(instance) group_right(cluster_name, store_prefix) (
+          stolon_cluster_identifier * on(instance) group_right(cluster_name) (
             stolon_keeper_needs_restart == 1
           )
         labels:

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -6,7 +6,7 @@ RUN set -x \
       && cd "${GOPATH}/src/github.com/sorintlab/stolon" \
       && git remote add gocardless https://github.com/gocardless/stolon \
       && git fetch gocardless \
-      && git checkout b937766b4a8884b8823547a2ef3a46040f00d245 \
+      && git checkout 71d109541f800fcacb2d8e3222715d84e569ccb5 \
       && go build -o stolon-keeper cmd/keeper/main.go
 
 


### PR DESCRIPTION
https://github.com/sorintlab/stolon/pull/639

Stolon maintainers reckon the store_prefix isn't necessary to have in
our metric labels. We've removed this upstream in the keeper, so we
should adjust our stolon-pgbouncer binaries to match.

This commit makes the change and bumps our development image to
recognise it, inclusive of updating dashboards and alerts.