### PR TITLE
Amend cluster specification: role

### DIFF
--- a/docker/stolon-development/stolon/specification.json
+++ b/docker/stolon-development/stolon/specification.json
@@ -13,7 +13,7 @@
   "additionalWalSenders": 5,
   "additionalMasterReplicationSlots": [],
   "mergePgParameters": true,
-  "clusterRole": "master",
+  "role": "master",
   "automaticPgRestart": false,
   "usePgrewind": true,
   "pgParameters": {


### PR DESCRIPTION
This used the wrong key, it's meant to be role.