### PR TITLE
Add health check endpoint

### DIFF
--- a/cmd/stolon-pgbouncer/main_test.go
+++ b/cmd/stolon-pgbouncer/main_test.go
@@ -1,21 +1,53 @@
-package main_test
+package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var _ = Describe("Health check endpoint", func() {
-	Context("When last master ip update < health check timeout", func() {
+	gauge := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_pbouncer_store_last_update_seconds",
+		},
+	)
+
+	handler := newHealthCheckHandler(gauge)
+
+	// In production this comes from a CLI flag
+	threshold := 60 * time.Second
+	superviseStoreUpdateMaxAge = &threshold
+
+	Context("When the last store update happened within the threshold", func() {
 		It("It responds 200", func() {
+			recorder := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", "/health_check", nil)
+			Expect(err).ToNot(HaveOccurred())
 
+			gauge.Set(float64(time.Now().Unix()))
+
+			handler(recorder, req)
+
+			Expect(recorder.Result().StatusCode).To(Equal(200))
 		})
 	})
 
-	Context("When last master ip update > health check timeout", func() {
+	Context("When the last store update happened longer ago than the threshold", func() {
 		It("It responds 500", func() {
+			recorder := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", "/health_check", nil)
+			Expect(err).ToNot(HaveOccurred())
 
+			gauge.Set(0)
+
+			handler(recorder, req)
+
+			Expect(recorder.Result().StatusCode).To(Equal(500))
 		})
 	})
-
 })

--- a/cmd/stolon-pgbouncer/main_test.go
+++ b/cmd/stolon-pgbouncer/main_test.go
@@ -1,0 +1,21 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Health check endpoint", func() {
+	Context("When last master ip update < health check timeout", func() {
+		It("It responds 200", func() {
+
+		})
+	})
+
+	Context("When last master ip update > health check timeout", func() {
+		It("It responds 500", func() {
+
+		})
+	})
+
+})

--- a/cmd/stolon-pgbouncer/suite_test.go
+++ b/cmd/stolon-pgbouncer/suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cmd/stolon-pgbouncer/main")
+}


### PR DESCRIPTION
Adds a health_check endpoint that responds 200 if the last master IP
update was within the health check timeout. If it isn't it responds 500.

Required for https://github.com/gocardless/anu/pull/2245