### PR TITLE
Retry watch indefinitely

### DIFF
--- a/cmd/stolon-pgbouncer/main.go
+++ b/cmd/stolon-pgbouncer/main.go
@@ -50,6 +50,7 @@ var (
 	superviseStolonOptions              = newStolonOptions(supervise)
 	supervisePgBouncerOptions           = newPgBouncerOptions(supervise)
 	supervisePollInterval               = supervise.Flag("poll-interval", "Store poll interval").Default("1m").Duration()
+	superviseWatchRetryInterval         = supervise.Flag("watch-retry-interval", "Interval to retry constructing an etcd watcher").Default("5s").Duration()
 	supervisePgBouncerTimeout           = supervise.Flag("pgbouncer-timeout", "Timeout for PgBouncer operations").Default("5s").Duration()
 	supervisePgBouncerRetryTimeout      = supervise.Flag("pgbouncer-retry-timeout", "Retry failed PgBouncer operations at this interval").Default("5s").Duration()
 	childProcessTerminationGracePeriod  = supervise.Flag("termination-grace-period", "Pause before rejecting new PgBouncer connections (on shutdown)").Default("5s").Duration()
@@ -400,9 +401,10 @@ func main() {
 			var logger = kitlog.With(logger, "component", "pgbouncer.watch")
 
 			streamOptions := etcd.StreamOptions{
-				Ctx:          ctx,
-				GetTimeout:   stopt.Timeout,
-				PollInterval: *supervisePollInterval,
+				Ctx:                ctx,
+				GetTimeout:         stopt.Timeout,
+				PollInterval:       *supervisePollInterval,
+				WatchRetryInterval: *superviseWatchRetryInterval,
 				Keys: []string{
 					fmt.Sprintf("%s/%s/clusterdata", stopt.Prefix, stopt.ClusterName),
 				},


### PR DESCRIPTION
Instead of terminating whenever we receive an error from the etcd
watcher, instead retry indefinitely on the assumption that this will
eventually succeed. This prevents us going into a termination state from
a recoverable etcd error, and we can rely on the downstream stolon proxy
to ensure we never connect to a bad (non-primary) node.

We also make our watcher more fussy, by rejecting any watch streams that
have ended up coming from a non-leader etcd node. This should ensure we
don't ever get stuck speaking to an etcd node that is partitioned from
the leader and not try to reconnect to a more up-to-date member.