### PR TITLE
Fix caller log key

### DIFF
--- a/cmd/stolon-pgbouncer/main.go
+++ b/cmd/stolon-pgbouncer/main.go
@@ -194,7 +194,6 @@ func main() {
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	logger = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
-	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
 
 	if *debug {
@@ -202,6 +201,10 @@ func main() {
 	} else {
 		logger = level.NewFilter(logger, level.AllowInfo())
 	}
+
+	// Apply default caller after levelling the logger, to prevent the called field being
+	// set to level.go:63 all the time.
+	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
 
 	go func() {
 		logger.Log("event", "metrics.listen", "address", *metricsAddress, "port", *metricsPort)


### PR DESCRIPTION
Apply the kitlog.With in the correct location to ensure the
DefaultCaller function can correctly identify call location.