### PR TITLE
Locally scoped break label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-acceptance: docker-compose
 clean:
 	rm -rvf $(PROG) $(PROG:%=%.linux_amd64)
 
-docker-compose: bin/stolon-pgbouncer.linux_amd64
+docker-compose: clean bin/stolon-pgbouncer.linux_amd64
 	docker-compose up --no-start
 	docker-compose start
 


### PR DESCRIPTION
@hmac this probably fixes most of the issues you had with the goto? Maybe?

After a discussion about the metrics of gotos, I think this might be a
better expression of the codes aims. The benefits are that label usage
is scoped to your current method and can't jump around anywhere, and you
have a code brace {} that encloses all the label usage.
