### PR TITLE
o11y: Expose PgBouncer metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
 
 BASE_TAG=2019040201
 CIRCLECI_TAG=2019040303
-STOLON_DEVELOPMENT_TAG=2019051001
+STOLON_DEVELOPMENT_TAG=2019051601
 
 .PHONY: all darwin linux test clean test-acceptance docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - etcd-store
 
   sentinel:
-    image: &stolonDevelopmentImage gocardless/stolon-development:2019051001
+    image: &stolonDevelopmentImage gocardless/stolon-development:2019051601
     restart: on-failure
     depends_on:
       - etcd-store
@@ -34,13 +34,9 @@ services:
   pgbouncer:
     hostname: pgbouncer
     image: *stolonDevelopmentImage
+    command:
+      - /stolon-pgbouncer/docker/stolon-development/supervisord-pgbouncer.conf
     restart: on-failure
-    user: postgres
-    entrypoint:
-      - /stolon-pgbouncer/bin/stolon-pgbouncer.linux_amd64
-      - supervise
-      - --metrics-address=0.0.0.0
-      - --pgbouncer-config-template-file=/stolon-pgbouncer/docker/stolon-development/pgbouncer/pgbouncer.ini.template
     volumes:
       - .:/stolon-pgbouncer
     ports:
@@ -53,6 +49,8 @@ services:
   keeper0:
     hostname: keeper0
     image: *stolonDevelopmentImage
+    command:
+      - /stolon-pgbouncer/docker/stolon-development/supervisord.conf
     restart: on-failure
     volumes:
       - keeper0-data:/data
@@ -65,6 +63,8 @@ services:
   keeper1:
     hostname: keeper1
     image: *stolonDevelopmentImage
+    command:
+      - /stolon-pgbouncer/docker/stolon-development/supervisord.conf
     restart: on-failure
     volumes:
       - keeper1-data:/data
@@ -77,6 +77,8 @@ services:
   keeper2:
     hostname: keeper2
     image: *stolonDevelopmentImage
+    command:
+      - /stolon-pgbouncer/docker/stolon-development/supervisord.conf
     restart: on-failure
     volumes:
       - keeper2-data:/data

--- a/docker/observability/grafana/dashboards/stolon-keeper.json
+++ b/docker/observability/grafana/dashboards/stolon-keeper.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 2,
-  "iteration": 1556638340861,
+  "id": 1,
+  "iteration": 1558014956765,
   "links": [],
   "panels": [
     {
@@ -35,8 +35,8 @@
       "scroll": true,
       "showHeader": true,
       "sort": {
-        "col": 3,
-        "desc": true
+        "col": 1,
+        "desc": false
       },
       "styles": [
         {
@@ -102,13 +102,102 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "Tracks the time passed since the last PgBouncer reload. We expect stolon-pgbouncer to periodically reload PgBouncer, so this has exceeded the store poll interval then we know PgBouncer reloading is failing.",
+      "description": "Number of client connections that are active via the PgBouncers.",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
         "y": 6
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (instance) (pgbouncer_pools_client_active_connections and on (instance) (stolon_cluster_identifier{cluster_name=\"$cluster\"} and on (instance) stolon_keeper_shutdown_seconds))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PgBouncer active connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Tracks the time passed since the last PgBouncer reload. We expect stolon-pgbouncer to periodically reload PgBouncer, so this has exceeded the store poll interval then we know PgBouncer reloading is failing.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 14
       },
       "id": 12,
       "legend": {
@@ -205,7 +294,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 22
       },
       "id": 16,
       "legend": {
@@ -399,5 +488,5 @@
   "timezone": "",
   "title": "stolon-keeper",
   "uid": "viJqeQkWk",
-  "version": 2
+  "version": 3
 }

--- a/docker/observability/grafana/dashboards/stolon-pgbouncer.json
+++ b/docker/observability/grafana/dashboards/stolon-pgbouncer.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 62,
-  "iteration": 1556008997240,
+  "id": 2,
+  "iteration": 1558016782331,
   "links": [],
   "panels": [
     {
@@ -35,7 +35,7 @@
       "scroll": true,
       "showHeader": true,
       "sort": {
-        "col": 3,
+        "col": 2,
         "desc": true
       },
       "styles": [
@@ -81,7 +81,7 @@
       ],
       "targets": [
         {
-          "expr": "max by (pod_name, cluster_name, keeper) (\n  time() - stolon_pgbouncer_store_last_update_seconds * on(pod_name) group_left(cluster_name, keeper) (\n    stolon_cluster_identifier{cluster_name=\"$cluster\"} != ignoring(cluster_name, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds\n  )\n)",
+          "expr": "max by (instance, cluster_name, keeper) (\n  time() - stolon_pgbouncer_store_last_update_seconds * on(instance) group_left(cluster_name, keeper) (\n    stolon_cluster_identifier{cluster_name=\"$cluster\"} != ignoring(cluster_name, keeper) group_left(keeper) stolon_pgbouncer_last_reload_seconds\n  )\n)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -130,6 +130,7 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -190,13 +191,104 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "Tracks the time passed since the last PgBouncer reload. We expect stolon-pgbouncer to periodically reload PgBouncer, so this has exceeded the store poll interval then we know PgBouncer reloading is failing.",
+      "description": "Number of client connections that are active via the PgBouncers, split by pod template hash.\n\nIf this is running in kubernetes and pod_template_hash specifies the replicaset version, you'll get a panel per active deployment of stolon-pgbouncer. This can help identify straggling deployments as they terminate.",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
         "y": 13
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "releases",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (instance) (pgbouncer_pools_client_active_connections{pod_template_hash=\"$releases\"} and on (instance) (stolon_cluster_identifier{cluster_name=\"$cluster\"} and on (instance) stolon_pgbouncer_shutdown_seconds))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PgBouncer active clients ($releases)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Tracks the time passed since the last PgBouncer reload. We expect stolon-pgbouncer to periodically reload PgBouncer, so this has exceeded the store poll interval then we know PgBouncer reloading is failing.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
       },
       "id": 12,
       "legend": {
@@ -218,6 +310,7 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -225,7 +318,7 @@
           "expr": "time() - ((stolon_pgbouncer_store_last_update_seconds > 0) and ignoring(cluster_name, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ instance }}",
           "refId": "A"
         }
       ],
@@ -292,7 +385,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "id": 16,
       "legend": {
@@ -314,6 +407,7 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -321,7 +415,7 @@
           "expr": "time() - ((stolon_pgbouncer_last_reload_seconds > 0) and ignoring(cluster_name, keeper) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ instance }}",
           "refId": "A"
         }
       ],
@@ -388,7 +482,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 37
       },
       "id": 11,
       "legend": {
@@ -410,6 +504,7 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
@@ -417,7 +512,7 @@
           "expr": "time() - ((stolon_pgbouncer_shutdown_seconds > 0) and ignoring(cluster_name) stolon_cluster_identifier{cluster_name=\"$cluster\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ instance }}",
           "refId": "A"
         }
       ],
@@ -481,7 +576,7 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 18,
+  "schemaVersion": 16,
   "style": "dark",
   "tags": [
     "postgres",
@@ -491,11 +586,13 @@
     "list": [
       {
         "current": {
-          "text": "mon-prometheus-0",
-          "value": "mon-prometheus-0"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
+        "includeAll": false,
         "label": null,
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -507,8 +604,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "lab-production/main",
-          "value": "lab-production/main"
+          "text": "main",
+          "value": "main"
         },
         "datasource": "$datasource",
         "definition": "label_values(stolon_cluster_identifier, cluster_name)",
@@ -523,6 +620,31 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "$datasource",
+        "definition": "query_result(count by (pod_template_hash) (min_over_time(stolon_cluster_identifier{cluster_name=\"$cluster\"}[$__range]) and on (instance) min_over_time(stolon_pgbouncer_shutdown_seconds[$__range])))",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "releases",
+        "options": [],
+        "query": "query_result(count by (pod_template_hash) (min_over_time(stolon_cluster_identifier{cluster_name=\"$cluster\"}[$__range]) and on (instance) min_over_time(stolon_pgbouncer_shutdown_seconds[$__range])))",
+        "refresh": 2,
+        "regex": "/pod_template_hash=\"([^\"]+)\"/",
+        "skipUrlSync": false,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -565,7 +687,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -589,5 +711,5 @@
   "timezone": "",
   "title": "stolon-pgbouncer",
   "uid": "0LgcjLRZz",
-  "version": 25
+  "version": 5
 }

--- a/docker/observability/prometheus/prometheus.yml
+++ b/docker/observability/prometheus/prometheus.yml
@@ -9,9 +9,27 @@ scrape_configs:
   - job_name: "stolon-pgbouncer"
     static_configs:
       - targets: ["pgbouncer:9446"]
+    relabel_configs: &relabel
+      - source_labels: [__address__]
+        regex: .+:(\d+)
+        target_label: port
+        replacement: ${1}
+      - source_labels: [__address__]
+        regex: (.+):\d+
+        target_label: instance
+        replacement: ${1}
   - job_name: "stolon-keeper"
     static_configs:
       - targets:
           - "keeper0:9459"
           - "keeper1:9459"
           - "keeper2:9459"
+    relabel_configs: *relabel
+  - job_name: "pgbouncer"
+    static_configs:
+      - targets:
+          - "pgbouncer:9127"
+          - "keeper0:9127"
+          - "keeper1:9127"
+          - "keeper2:9127"
+    relabel_configs: *relabel

--- a/docker/observability/prometheus/rules.yml
+++ b/docker/observability/prometheus/rules.yml
@@ -38,7 +38,7 @@ groups:
 
       - alert: StolonPgBouncerPendingShutdown
         expr: >
-          max by (pod_name, namespace, version) (
+          max by (instance, namespace, version) (
             stolon_cluster_identifier * ignoring(cluster_name) (
               time() - (stolon_pgbouncer_shutdown_seconds > 0)
             ) > 180
@@ -46,7 +46,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: PgBouncer is pending shutdown on {{ $labels.pod_name }}
+          summary: PgBouncer is pending shutdown on {{ $labels.instance }}
           dashboard: *dashboardStolonPgBouncer
           description: |
 
@@ -65,9 +65,9 @@ groups:
             querying the PgBouncer admin console.
 
             ```
-            $ kubectl logs -n {{ $labels.namespace }} {{ $labels.pod_name }} | grep outstanding_connections | tail -n 10
+            $ kubectl logs -n {{ $labels.namespace }} {{ $labels.instance }} | grep outstanding_connections | tail -n 10
             component=pgbouncer.child event=outstanding_connections database=postgres count=6
-            $ kubectl -n {{ $labels.namespace }} exec -it {{ $labels.pod_name }} bash
+            $ kubectl -n {{ $labels.namespace }} exec -it {{ $labels.instance }} bash
             postgres:/$ psql -p 6432 -U pgbouncer pgbouncer -h /tmp
             psql (11.2 (Ubuntu 11.2-1.pgdg18.04+1), server 1.9.0/bouncer)
             Type "help" for help.
@@ -80,7 +80,7 @@ groups:
         # Ensure we don't alert when shutdown_seconds > 0, as we'll have torn
         # down our etcd listeners once we begin shutdown.
         expr: >
-          max by (pod_name, namespace, version) (
+          max by (instance, namespace, version) (
             stolon_cluster_identifier * ignoring(cluster_name) (
               (time() - stolon_pgbouncer_store_last_update_seconds) > (6 * stolon_pgbouncer_store_poll_interval and stolon_pgbouncer_shutdown_seconds == 0)
             )
@@ -88,7 +88,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Stale clusterdata updates from etcd on {{ $labels.pod_name }}
+          summary: Stale clusterdata updates from etcd on {{ $labels.instance }}
           dashboard: *dashboardStolonPgBouncer
           description: |
 
@@ -102,7 +102,7 @@ groups:
             wrong.
 
             ```
-            $ kubectl logs -f -n {{ $labels.namespace }} {{ $labels.pod_name }}
+            $ kubectl logs -f -n {{ $labels.namespace }} {{ $labels.instance }}
             ```
 
       - alert: StolonPgBouncerStaleReload
@@ -113,7 +113,7 @@ groups:
         # As with StolonPgBouncerStaleStore, don't alert when we're shutting
         # down as we expect to stop listening to store updates on shutdown.
         expr: >
-          max by (pod_name, namespace, version) (
+          max by (instance, namespace, version) (
             stolon_cluster_identifier * ignoring(cluster_name) group_right(cluster_name) (
               stolon_pgbouncer_last_keeper_seconds - ignoring(keeper) stolon_pgbouncer_last_reload_seconds > 5
             )
@@ -121,7 +121,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: Failed to reload PgBouncer on {{ $labels.pod_name }}
+          summary: Failed to reload PgBouncer on {{ $labels.instance }}
           dashboard: *dashboardStolonPgBouncer
           description: |
 
@@ -136,7 +136,7 @@ groups:
             state of the PgBouncer process.
 
             ```
-            $ kubectl -n {{ $labels.namespace }} exec -it {{ $labels.pod_name }} bash
+            $ kubectl -n {{ $labels.namespace }} exec -it {{ $labels.instance }} bash
             postgres:/$ ps auxf
             ... # expect to see PgBouncer and stolon-pgbouncer
             postgres:/$ psql -p 6432 -U pgbouncer pgbouncer -h /tmp

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -9,6 +9,15 @@ RUN set -x \
       && git checkout 71d109541f800fcacb2d8e3222715d84e569ccb5 \
       && go build -o stolon-keeper cmd/keeper/main.go
 
+# GoCardless runs this fork for PgBouncer metrics. We'll likely change this in
+# future but include it for now so the dashboards in this repo can match what we
+# have deployed internally.
+FROM golang:1.12 AS pgbouncer-exporter-fork
+RUN set -x \
+      && go get -d -v github.com/gocardless/pgbouncer_exporter \
+      && cd "${GOPATH}/src/github.com/gocardless/pgbouncer_exporter" \
+      && git checkout a4ec94990b18f76dfd872b2a9214e827c52220a5 \
+      && make
 
 # In addition to our base install of pgbouncer and postgresql-client, configure
 # all the dependencies we'll need across our docker-compose setup along with
@@ -21,8 +30,8 @@ RUN set -x \
       && tar xfvz /tmp/stolon.tar.gz -C /usr/local/bin --wildcards '*/bin/*' --strip-components=2 \
       && rm -v /tmp/stolon.tar.gz
 
-# Load the GoCardless keeper fork
 COPY --from=stolon-fork /go/src/github.com/sorintlab/stolon/stolon-keeper /usr/local/bin/stolon-keeper
+COPY --from=pgbouncer-exporter-fork /go/src/github.com/gocardless/pgbouncer_exporter/pgbouncer_exporter /usr/local/bin/pgbouncer_exporter
 
 ENV ETCDCTL_API=3 \
     CLUSTER_NAME=main \
@@ -40,7 +49,8 @@ RUN mkdir /data && chown -R postgres:postgres /data
 # 6432 => PgBouncer
 # 7432 => stolon-proxy
 # 8080 => stolon-pgbouncer (pauser)
+# 9127 => pgbouncer_exporter (metrics)
 # 9459 => stolon-keeper (metrics)
 # 9446 => stolon-pgbouncer (metrics)
-EXPOSE 5432 6432 7432 8080 9459 9446
-ENTRYPOINT ["supervisord", "-n", "-c", "/stolon-pgbouncer/docker/stolon-development/supervisord.conf"]
+EXPOSE 5432 6432 7432 8080 9127 9459 9446
+ENTRYPOINT ["supervisord", "-n", "-c"]

--- a/docker/stolon-development/supervisord-pgbouncer.conf
+++ b/docker/stolon-development/supervisord-pgbouncer.conf
@@ -1,0 +1,14 @@
+[supervisord]
+user=root
+
+[program:stolon-pgbouncer]
+user=postgres
+command=/stolon-pgbouncer/bin/stolon-pgbouncer.linux_amd64 supervise --metrics-address=0.0.0.0 --pgbouncer-config-template-file=/stolon-pgbouncer/docker/stolon-development/pgbouncer/pgbouncer.ini.template
+stdout_logfile=/var/log/stolon-pgbouncer.log
+redirect_stderr=true
+
+[program:pgbouncer-exporter]
+user=postgres
+command=pgbouncer_exporter --pgBouncer.connectionString="user=pgbouncer host=localhost dbname=pgbouncer port=6432 sslmode=disable"
+stdout_logfile=/var/log/pgbouncer-exporter.log
+redirect_stderr=true

--- a/docker/stolon-development/supervisord.conf
+++ b/docker/stolon-development/supervisord.conf
@@ -30,3 +30,9 @@ user=postgres
 command=pgbouncer /stolon-pgbouncer/docker/stolon-development/pgbouncer/pgbouncer.ini
 stdout_logfile=/var/log/pgbouncer.log
 redirect_stderr=true
+
+[program:pgbouncer-exporter]
+user=postgres
+command=pgbouncer_exporter --pgBouncer.connectionString="user=pgbouncer host=localhost dbname=pgbouncer port=6432 sslmode=disable"
+stdout_logfile=/var/log/pgbouncer-exporter.log
+redirect_stderr=true


### PR DESCRIPTION
Modify the stolon development image to install the GC fork of the
pgbouncer-exporter then add it to the pgbouncer and keeper machines. Get
Prometheus scraping the PgBouncer metrics and exposing the active client
connections in the dashbaord.

Also switch our use of metric labels to assume instance is a human
readable fully-qualified hostname of the scrape target. This simplifies
several series joins.

![image](https://user-images.githubusercontent.com/3518874/57855968-dec14380-77e3-11e9-806a-0e09e06dcce3.png)

---

I've tested this by triggering a new rollout of the staging stolon-pgbouncer deployment to verify the metrics work correctly (`stolon-main-pgbouncer-backend-default`). Watching one of the rollouts, you'll see the following:

<img width="1424" alt="Screenshot 2019-05-16 at 15 38 16" src="https://user-images.githubusercontent.com/3518874/57862683-ac6a1300-77f0-11e9-9fd1-16cbeb266023.png">
