### PR TITLE
Use GC stolon binaries, not just keeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
 
 BASE_TAG=2019040201
 CIRCLECI_TAG=2019040303
-STOLON_DEVELOPMENT_TAG=2019051601
+STOLON_DEVELOPMENT_TAG=2019051602
 
 .PHONY: all darwin linux test clean test-acceptance docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - etcd-store
 
   sentinel:
-    image: &stolonDevelopmentImage gocardless/stolon-development:2019051601
+    image: &stolonDevelopmentImage gocardless/stolon-development:2019051602
     restart: on-failure
     depends_on:
       - etcd-store

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -7,7 +7,7 @@ RUN set -x \
       && git remote add gocardless https://github.com/gocardless/stolon \
       && git fetch gocardless \
       && git checkout 71d109541f800fcacb2d8e3222715d84e569ccb5 \
-      && go build -o stolon-keeper cmd/keeper/main.go
+      && ./build
 
 # GoCardless runs this fork for PgBouncer metrics. We'll likely change this in
 # future but include it for now so the dashboards in this repo can match what we
@@ -30,7 +30,13 @@ RUN set -x \
       && tar xfvz /tmp/stolon.tar.gz -C /usr/local/bin --wildcards '*/bin/*' --strip-components=2 \
       && rm -v /tmp/stolon.tar.gz
 
-COPY --from=stolon-fork /go/src/github.com/sorintlab/stolon/stolon-keeper /usr/local/bin/stolon-keeper
+COPY --from=stolon-fork \
+  /go/src/github.com/sorintlab/stolon/bin/stolon-keeper \
+  /go/src/github.com/sorintlab/stolon/bin/stolon-proxy \
+  /go/src/github.com/sorintlab/stolon/bin/stolon-sentinel \
+  /go/src/github.com/sorintlab/stolon/bin/stolonctl \
+  /usr/local/bin/
+
 COPY --from=pgbouncer-exporter-fork /go/src/github.com/gocardless/pgbouncer_exporter/pgbouncer_exporter /usr/local/bin/pgbouncer_exporter
 
 ENV ETCDCTL_API=3 \

--- a/docker/stolon-development/stolon/init.bash
+++ b/docker/stolon-development/stolon/init.bash
@@ -3,7 +3,7 @@
 set -eu -o pipefail
 
 if hostname | grep keeper0; then
-	if (stolonctl clusterdata 2>&1 || /bin/true) | grep 'nil cluster data: <nil>'; then
+	if (stolonctl clusterdata read 2>&1 || /bin/true) | grep 'nil cluster data: <nil>'; then
 		yes yes | stolonctl init -f /stolon-pgbouncer/docker/stolon-development/stolon/specification.json
 	fi
 fi


### PR DESCRIPTION
This commit changes our development setup to entirely use the GC fork of
stolon, not just the keeper. This makes more sense than just installing
the keeper, a decision we took when we believed we'd only modify stolon
once or twice.