### PR TITLE
Bump docker images for recent dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
 # release
 ################################################################################
 
-FROM gocardless/stolon-pgbouncer-base:2019040201 AS release
+FROM gocardless/stolon-pgbouncer-base:2019071601 AS release
 COPY --from=build /go/src/github.com/gocardless/stolon-pgbouncer/stolon-pgbouncer /usr/local/bin/stolon-pgbouncer
 USER postgres
 ENTRYPOINT ["/usr/local/bin/stolon-pgbouncer"]

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ PROJECT=github.com/gocardless/stolon-pgbouncer
 VERSION=$(shell git rev-parse --short HEAD)-dev
 BUILD_COMMAND=GO111MODULE=on go build -ldflags "-X main.Version=$(VERSION)"
 
-BASE_TAG=2019040201
-CIRCLECI_TAG=2019040303
-STOLON_DEVELOPMENT_TAG=2019060300
+BASE_TAG=2019071601
+CIRCLECI_TAG=2019071601
+STOLON_DEVELOPMENT_TAG=2019071601
 
 .PHONY: all darwin linux test clean test-acceptance docker-compose
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ references:
   docker_build_image: &docker_build_image
     working_directory: /go/src/github.com/gocardless/stolon-pgbouncer
     docker:
-      - image: &image gocardless/stolon-pgbouncer-circleci:2019040303
+      - image: &image gocardless/stolon-pgbouncer-circleci:2019071601
   docker_postgres_build_image: &docker_postgres_build_image
     working_directory: /go/src/github.com/gocardless/stolon-pgbouncer
     docker:

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -1,6 +1,6 @@
 # In addition to our base install of pgbouncer and postgresql-client, add CI
 # dependencies that we require during our builds.
-FROM gocardless/stolon-pgbouncer-base:2019040201
+FROM gocardless/stolon-pgbouncer-base:2019071601
 
 # General test utilities
 RUN set -x \

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
 # In addition to our base install of pgbouncer and postgresql-client, configure
 # all the dependencies we'll need across our docker-compose setup along with
 # convenience env vars to make stolon tooling function correctly.
-FROM gocardless/stolon-pgbouncer-base:2019040201
+FROM gocardless/stolon-pgbouncer-base:2019071601
 
 RUN set -x \
       && apt-get update -y \


### PR DESCRIPTION
This includes a pgbouncer version bump from 1.9 to 1.10, and should
confirm compatibility.