### PR TITLE
Increase acceptance tests timeout

### DIFF
--- a/cmd/stolon-pgbouncer-acceptance/main.go
+++ b/cmd/stolon-pgbouncer-acceptance/main.go
@@ -39,7 +39,7 @@ var _ = Describe("Acceptance", func() {
 
 	RegisterFailHandler(Fail)
 
-	SetDefaultEventuallyTimeout(time.Minute)
+	SetDefaultEventuallyTimeout(2 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))


### PR DESCRIPTION
CircleCI is sometimes slow at starting up the cluster and we fail in
CI as result. This bumps the default eventually timeout to 2 minutes
to give CircleCI extra time to bring the cluster up and into a
healthy state before starting our acceptance tests.