### PR TITLE
Bump docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
 # release
 ################################################################################
 
-FROM gocardless/stolon-pgbouncer-base:2019071601 AS release
+FROM gocardless/stolon-pgbouncer-base:2019082901 AS release
 COPY --from=build /go/src/github.com/gocardless/stolon-pgbouncer/stolon-pgbouncer /usr/local/bin/stolon-pgbouncer
 USER postgres
 ENTRYPOINT ["/usr/local/bin/stolon-pgbouncer"]

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ PROJECT=github.com/gocardless/stolon-pgbouncer
 VERSION=$(shell git rev-parse --short HEAD)-dev
 BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
 
-BASE_TAG=2019071601
-CIRCLECI_TAG=2019071601
-STOLON_DEVELOPMENT_TAG=2019082701
+BASE_TAG=2019082901
+CIRCLECI_TAG=2019082901
+STOLON_DEVELOPMENT_TAG=2019082901
 
 .PHONY: all darwin linux test clean test-acceptance docker-compose
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ references:
   docker_build_image: &docker_build_image
     working_directory: /go/src/github.com/gocardless/stolon-pgbouncer
     docker:
-      - image: &image gocardless/stolon-pgbouncer-circleci:2019071601
+      - image: &image gocardless/stolon-pgbouncer-circleci:2019082901
   docker_postgres_build_image: &docker_postgres_build_image
     working_directory: /go/src/github.com/gocardless/stolon-pgbouncer
     docker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - etcd-store
 
   sentinel:
-    image: &stolonDevelopmentImage gocardless/stolon-development:2019082701
+    image: &stolonDevelopmentImage gocardless/stolon-development:2019082901
     restart: on-failure
     depends_on:
       - etcd-store

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:bionic-20190807
 RUN set -x \
       && apt-get update -y \
       && apt-get install -y curl gpg \

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -1,6 +1,6 @@
 # In addition to our base install of pgbouncer and postgresql-client, add CI
 # dependencies that we require during our builds.
-FROM gocardless/stolon-pgbouncer-base:2019071601
+FROM gocardless/stolon-pgbouncer-base:2019082901
 
 # General test utilities
 RUN set -x \

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
 # In addition to our base install of pgbouncer and postgresql-client, configure
 # all the dependencies we'll need across our docker-compose setup along with
 # convenience env vars to make stolon tooling function correctly.
-FROM gocardless/stolon-pgbouncer-base:2019071601
+FROM gocardless/stolon-pgbouncer-base:2019082901
 
 RUN set -x \
       && apt-get update -y \


### PR DESCRIPTION
This refreshes our base images, particularly important given pgBouncer
is now at 1.11.0.