### PR TITLE
Remove unused stolon install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
 # release
 ################################################################################
 
-FROM gocardless/stolon-pgbouncer-base:2019082901 AS release
+FROM gocardless/stolon-pgbouncer-base:2019090201 AS release
 COPY --from=build /go/src/github.com/gocardless/stolon-pgbouncer/stolon-pgbouncer /usr/local/bin/stolon-pgbouncer
 USER postgres
 ENTRYPOINT ["/usr/local/bin/stolon-pgbouncer"]

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ PROJECT=github.com/gocardless/stolon-pgbouncer
 VERSION=$(shell git rev-parse --short HEAD)-dev
 BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
 
-BASE_TAG=2019082901
-CIRCLECI_TAG=2019082901
-STOLON_DEVELOPMENT_TAG=2019082901
+BASE_TAG=2019090201
+CIRCLECI_TAG=2019090201
+STOLON_DEVELOPMENT_TAG=2019090201
 
 .PHONY: all darwin linux test clean test-acceptance docker-compose
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ references:
   docker_build_image: &docker_build_image
     working_directory: /go/src/github.com/gocardless/stolon-pgbouncer
     docker:
-      - image: &image gocardless/stolon-pgbouncer-circleci:2019082901
+      - image: &image gocardless/stolon-pgbouncer-circleci:2019090201
   docker_postgres_build_image: &docker_postgres_build_image
     working_directory: /go/src/github.com/gocardless/stolon-pgbouncer
     docker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - etcd-store
 
   sentinel:
-    image: &stolonDevelopmentImage gocardless/stolon-development:2019082901
+    image: &stolonDevelopmentImage gocardless/stolon-development:2019090201
     restart: on-failure
     depends_on:
       - etcd-store

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -1,6 +1,6 @@
 # In addition to our base install of pgbouncer and postgresql-client, add CI
 # dependencies that we require during our builds.
-FROM gocardless/stolon-pgbouncer-base:2019082901
+FROM gocardless/stolon-pgbouncer-base:2019090201
 
 # General test utilities
 RUN set -x \

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -37,12 +37,6 @@ RUN set -x \
       && tar xfvz /tmp/docker.tar.gz -C /usr/local/bin docker/docker --strip-components=1 \
       && rm -v /tmp/docker.tar.gz
 
-# stolonctl is used by the acceptance test
-RUN set -x \
-      && curl -fsL https://github.com/sorintlab/stolon/releases/download/v0.13.0/stolon-v0.13.0-linux-amd64.tar.gz -o /tmp/stolon.tar.gz \
-      && tar xfvz /tmp/stolon.tar.gz -C /usr/local/bin --wildcards '*/bin/*' --strip-components=2 \
-      && rm -v /tmp/stolon.tar.gz
-
 # The acceptance test uses these environment variables
 ENV ETCDCTL_API=3 \
     CLUSTER_NAME=main \

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -26,10 +26,7 @@ FROM gocardless/stolon-pgbouncer-base:2019082901
 
 RUN set -x \
       && apt-get update -y \
-      && apt-get install --no-install-recommends -y curl etcd-client supervisor postgresql-11 \
-      && curl -fsL https://github.com/sorintlab/stolon/releases/download/v0.13.0/stolon-v0.13.0-linux-amd64.tar.gz -o /tmp/stolon.tar.gz \
-      && tar xfvz /tmp/stolon.tar.gz -C /usr/local/bin --wildcards '*/bin/*' --strip-components=2 \
-      && rm -v /tmp/stolon.tar.gz
+      && apt-get install --no-install-recommends -y curl etcd-client supervisor postgresql-11
 
 COPY --from=stolon-fork \
   /go/src/github.com/sorintlab/stolon/bin/stolon-keeper \

--- a/docker/stolon-development/Dockerfile
+++ b/docker/stolon-development/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
 # In addition to our base install of pgbouncer and postgresql-client, configure
 # all the dependencies we'll need across our docker-compose setup along with
 # convenience env vars to make stolon tooling function correctly.
-FROM gocardless/stolon-pgbouncer-base:2019082901
+FROM gocardless/stolon-pgbouncer-base:2019090201
 
 RUN set -x \
       && apt-get update -y \


### PR DESCRIPTION
We install stolon from the GoCardless fork, so don't keep the old
install method as this is misleading.