### PR TITLE
stolon-keeper: uptime, needs_restart

### DIFF
--- a/docker/observability/grafana/dashboards/stolon-keeper.json
+++ b/docker/observability/grafana/dashboards/stolon-keeper.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 1,
-  "iteration": 1566914971768,
+  "iteration": 1577470765332,
   "links": [],
   "panels": [
     {
@@ -72,6 +72,57 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Value #A",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "uptime",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 1,
+          "mappingType": 1,
+          "pattern": "Value #B",
+          "thresholds": [],
+          "type": "number",
+          "unit": "s"
+        },
+        {
+          "alias": "needs_restart",
+          "colorMode": "cell",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "Value #C",
+          "thresholds": [
+            "0.5",
+            "1"
+          ],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
           "decimals": 2,
           "pattern": "/.*/",
           "thresholds": [],
@@ -87,6 +138,20 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "expr": "max by (instance) (\n  time() - process_start_time_seconds and (stolon_keeper_shutdown_seconds and on(instance) stolon_cluster_identifier{cluster_name=\"$cluster\", component=\"keeper\"})\n)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "B"
+        },
+        {
+          "expr": "max by (instance) (\n  stolon_keeper_needs_restart and on(instance) stolon_cluster_identifier{cluster_name=\"$cluster\", component=\"keeper\"}\n)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "C"
         }
       ],
       "timeFrom": null,
@@ -469,6 +534,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "5s",
       "15s",
       "30s",
       "1m"


### PR DESCRIPTION
When performing maintenance on stolon-keepers, it's useful to know the
current uptime and whether the keeper requires a restart. This adds
those fields, making it easy for an operator to tick each keeper off a
checklist (they go green when fixed).

![image](https://user-images.githubusercontent.com/3518874/71528099-2c537200-28d6-11ea-8f32-8b3c8d8a75bb.png)
