### PR TITLE
Revert "Don't require ignore_startup_parameters"

### DIFF
--- a/docker/stolon-development/pgbouncer/pgbouncer.ini
+++ b/docker/stolon-development/pgbouncer/pgbouncer.ini
@@ -23,3 +23,4 @@ reserve_pool_size = 5
 log_connections = 1
 log_disconnections = 1
 log_pooler_errors = 1
+ignore_startup_parameters = extra_float_digits

--- a/docker/stolon-development/pgbouncer/pgbouncer.ini.template
+++ b/docker/stolon-development/pgbouncer/pgbouncer.ini.template
@@ -23,3 +23,4 @@ reserve_pool_size = 5
 log_connections = 1
 log_disconnections = 1
 log_pooler_errors = 1
+ignore_startup_parameters = extra_float_digits

--- a/pkg/pgbouncer/integration/pgbouncer.go
+++ b/pkg/pgbouncer/integration/pgbouncer.go
@@ -85,7 +85,8 @@ unix_socket_dir = %s
 auth_type = trust
 auth_file = %s/users.txt
 admin_users = postgres,pgbouncer
-pool_mode = %s`, database, port, workspace, workspace, workspace, poolMode)),
+pool_mode = %s
+ignore_startup_parameters = extra_float_digits`, database, port, workspace, workspace, workspace, poolMode)),
 			0644,
 		)
 

--- a/pkg/pgbouncer/pgbouncer.go
+++ b/pkg/pgbouncer/pgbouncer.go
@@ -71,6 +71,14 @@ func (b *PgBouncer) createTemplate() (*template.Template, error) {
 		return nil, errors.Wrap(err, "failed to read PgBouncer config template file")
 	}
 
+	if matched, _ := regexp.Match("ignore_startup_parameters\\s*\\=.+extra_float_digits", configTemplate); !matched {
+		return nil, errors.Errorf(
+			"PgBouncer is misconfigured: expected config file '%s' to define "+
+				"'ignore_startup_paramets' to include 'extra_float_digits'",
+			b.ConfigTemplateFile,
+		)
+	}
+
 	return template.Must(template.New("PgBouncerConfig").Parse(string(configTemplate))), err
 }
 

--- a/pkg/pgbouncer/testdata/pgbouncer.ini.template
+++ b/pkg/pgbouncer/testdata/pgbouncer.ini.template
@@ -21,3 +21,4 @@ reserve_pool_size = 5
 log_connections = 1
 log_disconnections = 1
 log_pooler_errors = 1
+ignore_startup_parameters = extra_float_digits


### PR DESCRIPTION
Add back the libpq workarounds that were taken out in PR #16

This reverts commit c806ed3c608dd48781d5a0e7b44cb8e3e0988cf0.