### PR TITLE
Add healthchecks and build contexts to the docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
 
   sentinel:
     image: &stolonDevelopmentImage gocardless/stolon-development:2022030901
+    build: &stolonDevelopmentBuild
+      context: docker/stolon-development
     restart: on-failure
     depends_on:
       - etcd-store
@@ -31,10 +33,13 @@ services:
       - --store-backend=etcdv3
       - --store-endpoints=etcd-store:2379
       - --metrics-listen-address=0.0.0.0:9459
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9459/metrics"]
 
   pgbouncer:
     hostname: pgbouncer
     image: *stolonDevelopmentImage
+    build: *stolonDevelopmentBuild
     command:
       - /stolon-pgbouncer/docker/stolon-development/supervisord-pgbouncer.conf
     restart: on-failure
@@ -43,13 +48,17 @@ services:
     ports:
       - "6432:6432"
     depends_on:
-      - keeper0
-      - keeper1
-      - keeper2
+      keeper0:
+        condition: service_healthy
+      keeper1:
+        condition: service_healthy
+      keeper2:
+        condition: service_healthy
 
   keeper0:
     hostname: keeper0
     image: *stolonDevelopmentImage
+    build: *stolonDevelopmentBuild
     command:
       - /stolon-pgbouncer/docker/stolon-development/supervisord.conf
     restart: on-failure
@@ -62,11 +71,15 @@ services:
     ports:
       - "6433:6432"
     depends_on:
-      - sentinel
+      sentinel:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/bin/pg_isready", "-h", "/tmp"]
 
   keeper1:
     hostname: keeper1
     image: *stolonDevelopmentImage
+    build: *stolonDevelopmentBuild
     command:
       - /stolon-pgbouncer/docker/stolon-development/supervisord.conf
     restart: on-failure
@@ -79,11 +92,15 @@ services:
     ports:
       - "6434:6432"
     depends_on:
-      - sentinel
+      sentinel:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/bin/pg_isready", "-h", "/tmp"]
 
   keeper2:
     hostname: keeper2
     image: *stolonDevelopmentImage
+    build: *stolonDevelopmentBuild
     command:
       - /stolon-pgbouncer/docker/stolon-development/supervisord.conf
     restart: on-failure
@@ -93,7 +110,10 @@ services:
     ports:
       - "6435:6432"
     depends_on:
-      - sentinel
+      sentinel:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/bin/pg_isready", "-h", "/tmp"]
 
   prometheus:
     image: prom/prometheus
@@ -109,11 +129,14 @@ services:
     restart: always
     ports:
       - 9090:9090
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:9090"]
 
   grafana:
     image: grafana/grafana
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
     volumes:
       - ./docker/observability/grafana/dashboards:/var/lib/grafana/dashboards
       - ./docker/observability/grafana/dashboard-provisioner.yml:/etc/grafana/provisioning/dashboards/provisioner.yml


### PR DESCRIPTION
This change adds some healthchecks, and the tracking of said
healthchecks for dependencies to start in a more consistent manner.

Also included in this change are `build` rules for when the provided
images aren't already available on the machine, falling back to
building them each time. This additionally provides the ability to run
`docker compose build` to rebuild relevant images.